### PR TITLE
Added function to_CRNS_format()

### DIFF
--- a/pyRN/SAE/sos.py
+++ b/pyRN/SAE/sos.py
@@ -237,3 +237,13 @@ def frequencies(elements):
                 ue[1] += 1
                 
     return unique_elements
+
+def to_CRNS_format(array):
+    '''
+    Converts representation ofthe set to CRNS format
+    '''
+    a = []
+    for i in range(len(array)):
+        if array[i]==1:
+            a.append(f's{i}')
+    return numpy.array(a)


### PR DESCRIPTION
A function that converts from the representation that I use ( [0, 1, 0, 0, 1], list) to the representation used in CRNS ( ['s1' 's4'], numpy.ndarray)